### PR TITLE
Resolve UIDevice not available on macOS

### DIFF
--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -24,6 +24,7 @@ internal class DeviceInfo {
         return Bundle.main.bundlePath.hasSuffix(".appex")
     }
     
+    #if canImport(UIKit)
     private static func getiOSUserAgent() -> String {
         if !isRunningInExtension() {
             let webView = WKWebView(frame: .zero)
@@ -68,6 +69,7 @@ internal class DeviceInfo {
 
         return userAgent
     }
+    #endif
 
     private static func getMacOSUserAgent() -> String {
         let processInfo = ProcessInfo.processInfo


### PR DESCRIPTION
Added a simple conditional compilation block for `getiOSUserAgent` and `getBasicUserAgent` which is dependent on `UIDevice` which isn't available on macOS which is currently preventing use on mac apps.