### PR TITLE
CI for cross platform compilation and apple device metadata refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .DS_Store
 .build/*
+
+## User settings
+xcuserdata/
+
+.swiftpm

--- a/OpenPanel-Swift-SDK.xcodeproj/project.pbxproj
+++ b/OpenPanel-Swift-SDK.xcodeproj/project.pbxproj
@@ -1,0 +1,497 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D06380072DC47A6F00E2B156 /* OpenPanel_Swift_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0637FFD2DC47A6F00E2B156 /* OpenPanel_Swift_SDK.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D06380082DC47A6F00E2B156 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D0637FF42DC47A6F00E2B156 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D0637FFC2DC47A6F00E2B156;
+			remoteInfo = "OpenPanel-Swift-SDK";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		D0637FFD2DC47A6F00E2B156 /* OpenPanel_Swift_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OpenPanel_Swift_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D06380062DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OpenPanel-Swift-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D0637FFF2DC47A6F00E2B156 /* OpenPanel-Swift-SDK */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "OpenPanel-Swift-SDK";
+			sourceTree = "<group>";
+		};
+		D063800A2DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "OpenPanel-Swift-SDKTests";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D0637FFA2DC47A6F00E2B156 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D06380032DC47A6F00E2B156 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D06380072DC47A6F00E2B156 /* OpenPanel_Swift_SDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D0637FF32DC47A6F00E2B156 = {
+			isa = PBXGroup;
+			children = (
+				D0637FFF2DC47A6F00E2B156 /* OpenPanel-Swift-SDK */,
+				D063800A2DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests */,
+				D0637FFE2DC47A6F00E2B156 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D0637FFE2DC47A6F00E2B156 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D0637FFD2DC47A6F00E2B156 /* OpenPanel_Swift_SDK.framework */,
+				D06380062DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		D0637FF82DC47A6F00E2B156 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		D0637FFC2DC47A6F00E2B156 /* OpenPanel-Swift-SDK */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D063800F2DC47A6F00E2B156 /* Build configuration list for PBXNativeTarget "OpenPanel-Swift-SDK" */;
+			buildPhases = (
+				D0637FF82DC47A6F00E2B156 /* Headers */,
+				D0637FF92DC47A6F00E2B156 /* Sources */,
+				D0637FFA2DC47A6F00E2B156 /* Frameworks */,
+				D0637FFB2DC47A6F00E2B156 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D0637FFF2DC47A6F00E2B156 /* OpenPanel-Swift-SDK */,
+			);
+			name = "OpenPanel-Swift-SDK";
+			packageProductDependencies = (
+			);
+			productName = "OpenPanel-Swift-SDK";
+			productReference = D0637FFD2DC47A6F00E2B156 /* OpenPanel_Swift_SDK.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D06380052DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D06380122DC47A6F00E2B156 /* Build configuration list for PBXNativeTarget "OpenPanel-Swift-SDKTests" */;
+			buildPhases = (
+				D06380022DC47A6F00E2B156 /* Sources */,
+				D06380032DC47A6F00E2B156 /* Frameworks */,
+				D06380042DC47A6F00E2B156 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D06380092DC47A6F00E2B156 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				D063800A2DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests */,
+			);
+			name = "OpenPanel-Swift-SDKTests";
+			packageProductDependencies = (
+			);
+			productName = "OpenPanel-Swift-SDKTests";
+			productReference = D06380062DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D0637FF42DC47A6F00E2B156 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1630;
+				LastUpgradeCheck = 1630;
+				TargetAttributes = {
+					D0637FFC2DC47A6F00E2B156 = {
+						CreatedOnToolsVersion = 16.3;
+					};
+					D06380052DC47A6F00E2B156 = {
+						CreatedOnToolsVersion = 16.3;
+					};
+				};
+			};
+			buildConfigurationList = D0637FF72DC47A6F00E2B156 /* Build configuration list for PBXProject "OpenPanel-Swift-SDK" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D0637FF32DC47A6F00E2B156;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = D0637FFE2DC47A6F00E2B156 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D0637FFC2DC47A6F00E2B156 /* OpenPanel-Swift-SDK */,
+				D06380052DC47A6F00E2B156 /* OpenPanel-Swift-SDKTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D0637FFB2DC47A6F00E2B156 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D06380042DC47A6F00E2B156 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D0637FF92DC47A6F00E2B156 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D06380022DC47A6F00E2B156 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D06380092DC47A6F00E2B156 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D0637FFC2DC47A6F00E2B156 /* OpenPanel-Swift-SDK */;
+			targetProxy = D06380082DC47A6F00E2B156 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		D063800D2DC47A6F00E2B156 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D063800E2DC47A6F00E2B156 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D06380102DC47A6F00E2B156 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.openpanel.OpenPanel-Swift-SDK";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+				XROS_DEPLOYMENT_TARGET = 2.4;
+			};
+			name = Debug;
+		};
+		D06380112DC47A6F00E2B156 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.openpanel.OpenPanel-Swift-SDK";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+				XROS_DEPLOYMENT_TARGET = 2.4;
+			};
+			name = Release;
+		};
+		D06380132DC47A6F00E2B156 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.openpanel.OpenPanel-Swift-SDKTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.4;
+			};
+			name = Debug;
+		};
+		D06380142DC47A6F00E2B156 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.openpanel.OpenPanel-Swift-SDKTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.4;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D0637FF72DC47A6F00E2B156 /* Build configuration list for PBXProject "OpenPanel-Swift-SDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D063800D2DC47A6F00E2B156 /* Debug */,
+				D063800E2DC47A6F00E2B156 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D063800F2DC47A6F00E2B156 /* Build configuration list for PBXNativeTarget "OpenPanel-Swift-SDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D06380102DC47A6F00E2B156 /* Debug */,
+				D06380112DC47A6F00E2B156 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D06380122DC47A6F00E2B156 /* Build configuration list for PBXNativeTarget "OpenPanel-Swift-SDKTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D06380132DC47A6F00E2B156 /* Debug */,
+				D06380142DC47A6F00E2B156 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D0637FF42DC47A6F00E2B156 /* Project object */;
+}

--- a/OpenPanel-Swift-SDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/OpenPanel-Swift-SDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/OpenPanel-Swift-SDKTests/OpenPanel_Swift_SDKTests.swift
+++ b/OpenPanel-Swift-SDKTests/OpenPanel_Swift_SDKTests.swift
@@ -1,0 +1,17 @@
+//
+//  OpenPanel_Swift_SDKTests.swift
+//  OpenPanel-Swift-SDKTests
+//
+//  Created by Justin Doody on 5/1/25.
+//
+
+import Testing
+@testable import OpenPanel_Swift_SDK
+
+struct OpenPanel_Swift_SDKTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,19 +5,17 @@ let package = Package(
     name: "OpenPanel",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15)
+        .macOS(.v10_15),
+        .tvOS(.v15)
     ],
     products: [
         .library(
             name: "OpenPanel",
             targets: ["OpenPanel"]),
     ],
-    dependencies: [
-        // Add any external dependencies here
-    ],
     targets: [
         .target(
             name: "OpenPanel",
-            dependencies: []),
+            path: "OpenPanel-Swift-SDK")
     ]
 )

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -24,6 +24,7 @@ internal class DeviceInfo {
         return Bundle.main.bundlePath.hasSuffix(".appex")
     }
     
+    #if canImport(UIKit)
     private static func getiOSUserAgent() -> String {
         if !isRunningInExtension() {
             let webView = WKWebView(frame: .zero)
@@ -68,6 +69,7 @@ internal class DeviceInfo {
 
         return userAgent
     }
+    #endif
 
     private static func getMacOSUserAgent() -> String {
         let processInfo = ProcessInfo.processInfo

--- a/scripts/test-builds.sh
+++ b/scripts/test-builds.sh
@@ -1,0 +1,23 @@
+    #!/bin/bash
+    # Exit immediately if a command exits with a non-zero status.
+    set -e
+
+    echo "--- Cleaning ---"
+    swift package clean
+    # Alternatively, use: xcodebuild clean -scheme OpenPanel
+
+    echo "--- Building for macOS ---"
+    # Builds for the native architecture of your Mac (Intel or Apple Silicon)
+    set -o pipefail && xcodebuild build -scheme OpenPanel-Swift-SDK -sdk macosx | xcpretty
+
+    echo "--- Building for iOS Device (ARM64) ---"
+    # Uses CODE_SIGNING_ALLOWED=NO to bypass code signing issues for compilation check
+    set -o pipefail && xcodebuild build -scheme OpenPanel-Swift-SDK -sdk iphoneos CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty
+
+    echo "--- Building for tvOS Device (ARM64) ---"
+    set -o pipefail && xcodebuild build -scheme OpenPanel-Swift-SDK -sdk appletvos CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty
+
+    # echo "--- Building for watchOS Device ---"
+    # xcodebuild build -scheme OpenPanel -sdk watchos CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty
+
+    echo "--- All targeted builds completed successfully! ---"


### PR DESCRIPTION
This isn't quite ready to merge but I wanted to discuss at this current state.

First off the existing package only works on iOS at the moment due to issues with dependencies on the conditional blocks. I'm working on a cross platform app targeting macOS, iOS, and tvOS and implementing OpenPanel. (By the way the OpenPanel docs don't mention this SDK existing -- luckily i checked github issues before trying to build one myself)

This branch accomplishes two things primarily:
- Added github CI to run xcodebuild targeting the three OS's i mentioned above (could potentially expand to watchOS and visionOS -- i just didn't need em). I needed to add the workspace/project to get `xcodebuild` to actually run. Supposedly it worked with just plain packages in the past but I couldn't get it to and docs are sparse.
- Refactors approach to device metadata. This is the area I wanted to discuss. I think we could just get rid of the user agent approach entirely for Apple apps. Trying to figure out how to force/format various data into a format ua-parser-js would properly parse is a real pain and i don't think for some things it will work at all (like specific model numbers of devices). The approach i took here is just injecting various params into the `_global` at init. Because of the `isServer` checks on the OpenPanel side at least a minimal user agent is need like `"Mozilla/5.0 (iPhone; U)"` to avoid that (though that side of things could be refactored too I suppose).

I think it would be good to get rid of the whole `WKWebView` dependency for iOS. Is there any value in getting this UserAgent when using OpenPanel for apps?

Here is an example of tracking the apple model identifier instead of the more generic Macintosh or iPhone for all devices.
<img width="423" alt="Screenshot 2025-05-02 at 6 43 59 PM" src="https://github.com/user-attachments/assets/f7eeaa2b-cd66-4222-ab42-42643e2b1802" />


