### PR TITLE
Fix user-agent, identify-merge, and thread-safety bugs; declare tvOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ let package = Package(
     name: "OpenPanel",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15)
+        .macOS(.v10_15),
+        .tvOS(.v13)
     ],
     products: [
         .library(

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -453,7 +453,7 @@ public class OpenPanel {
                 if let global = shared._global {
                     var mergedProperties = global
                     if let payloadProperties = payload.properties {
-                        mergedProperties.merge(payloadProperties) { (_, new) in (new as AnyObject).value }
+                        mergedProperties.merge(payloadProperties) { (_, new) in (new as? AnyCodable)?.value ?? new }
                     }
                     updatedPayload.properties = mergedProperties.mapValues { AnyCodable($0) }
                 }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -383,7 +383,9 @@ public class OpenPanel {
         }
         
         if options.waitForProfile == true, profileId == nil {
-            queue.append(payload)
+            globalQueue.async(flags: .barrier) {
+                self.queue.append(payload)
+            }
             return
         }
         
@@ -482,8 +484,11 @@ public class OpenPanel {
     }
     
     public func flush() {
-        let currentQueue = queue
-        queue.removeAll()
+        let currentQueue = globalQueue.sync(flags: .barrier) { () -> [TrackHandlerPayload] in
+            let items = queue
+            queue.removeAll()
+            return items
+        }
         for item in currentQueue {
             send(item)
         }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -332,7 +332,7 @@ public class OpenPanel {
     private var options: Options?
     
     public static var sdkVersion: String {
-        return "0.0.1"
+        return "1.0.1"
     }
     
     private init() {

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -43,13 +43,11 @@ internal class DeviceInfo {
             
             _ = semaphore.wait(timeout: .now() + 1.0)
 
-            userAgent += " OpenPanel/\(OpenPanel.sdkVersion)"
-            
             if userAgent.isEmpty {
-                userAgent = getBasicUserAgent()
+                return getBasicUserAgent()
             }
-            
-            return userAgent
+
+            return userAgent + " OpenPanel/\(OpenPanel.sdkVersion)"
         } else {
             return getBasicUserAgent()
         }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -72,12 +72,10 @@ internal class DeviceInfo {
     #endif
 
     private static func getMacOSUserAgent() -> String {
-        let processInfo = ProcessInfo.processInfo
-        let osVersion = processInfo.operatingSystemVersionString
-        let versionParts = osVersion.components(separatedBy: " ")
-        let version = versionParts.count > 1 ? versionParts[1] : "Unknown"
-        
-        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X \(version.replacingOccurrences(of: ".", with: "_"))) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let version = "\(osVersion.majorVersion)_\(osVersion.minorVersion)_\(osVersion.patchVersion)"
+
+        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X \(version)) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
         
         return userAgent + " OpenPanel/\(OpenPanel.sdkVersion)"
     }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -2,6 +2,8 @@ import Foundation
 #if os(iOS)
 import UIKit
 import WebKit
+#elseif os(tvOS)
+import UIKit
 #elseif os(macOS)
 import AppKit
 import WebKit


### PR DESCRIPTION
Six small, independent fixes — one commit each — found while reviewing the SDK. No public API changes.

## Fixes

1. **macOS user agent built from structured `operatingSystemVersion`** instead of splitting the localized `operatingSystemVersionString`, which Apple documents as display-only and not machine-parseable.
2. **`sdkVersion` aligned with the release version** (0.0.1 → 1.0.1). The string goes into the `openpanel-sdk-version` header and every user agent; it had never been bumped past 0.0.1 even though the repo is tagged 1.0.0.
3. **iOS user-agent fallback made reachable.** The `isEmpty` check ran *after* appending ` OpenPanel/<version>`, so the string was never empty and `getBasicUserAgent()` was dead code — a WKWebView failure/timeout produced a UA of just ` OpenPanel/0.0.1`. The check now runs first.
4. **`identify` property merge no longer uses AnyObject dynamic lookup.** `(new as AnyObject).value` resolved via the ObjC runtime against a boxed Swift struct, returning nil at runtime and corrupting merged properties (the compiler flagged it with an `Any??` coercion warning). Replaced with `(new as? AnyCodable)?.value ?? new`; the build is now warning-free.
5. **Pending-event queue synchronized.** The `waitForProfile` buffer was appended and flushed from arbitrary threads with no synchronization, despite the README's thread-safety claim. Appends now go through the existing barrier queue and `flush()` snapshots-and-clears atomically.
6. **tvOS declared in Package.swift** (+ UIKit import). The source already had `os(tvOS)` branches, but without the platform declaration they had never compiled.

## Verification

`swift build` (macOS) with zero warnings; `xcodebuild` BUILD SUCCEEDED for iOS Simulator and tvOS Simulator.

## Note on releasing

Please cut a new tag after merging: SPM users on `.upToNextMajor(from: "1.0.0")` are still resolving tag 1.0.0 and have never received the macOS compile fix (9b0c524) that is already on `main`. A new release finally ships it to them, along with these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tvOS 13 and later.
  - Updated SDK version information to 1.0.1.

- **Bug Fixes**
  - Improved device and operating-system identification across iOS and macOS.
  - Fixed handling of queued events when waiting for profile information.
  - Improved property merging during profile identification.
  - Enhanced queue synchronization to help ensure events are captured and sent reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->