### PR TITLE
Replace fabricated user agents with structured device info; add watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ let package = Package(
     name: "OpenPanel",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15)
+        .macOS(.v10_15),
+        .tvOS(.v13)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macOS(.v10_15),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .watchOS(.v7)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The OpenPanel Swift SDK allows you to integrate OpenPanel analytics into your iO
 
 ## Requirements
 
-- iOS 13.0+ / macOS 10.15+ / tvOS 13.0+ / watchOS 6.0+
+- iOS 13.0+ / macOS 10.15+ / tvOS 13.0+ / watchOS 7.0+
 - Xcode 12.0+
 - Swift 5.3+
 

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -453,7 +453,7 @@ public class OpenPanel {
                 if let global = shared._global {
                     var mergedProperties = global
                     if let payloadProperties = payload.properties {
-                        mergedProperties.merge(payloadProperties) { (_, new) in (new as AnyObject).value }
+                        mergedProperties.merge(payloadProperties) { (_, new) in (new as? AnyCodable)?.value ?? new }
                     }
                     updatedPayload.properties = mergedProperties.mapValues { AnyCodable($0) }
                 }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -307,7 +307,9 @@ public class OpenPanel {
         set { globalQueue.async(flags: .barrier) { self._global = newValue } }
     }
     private var queue: [TrackHandlerPayload] = []
-    private let operationQueue: OperationQueue
+    // Tail of the in-flight send chain; each new send awaits the previous one
+    // so events reach the server in the order they were tracked.
+    private var sendTask: Task<Void, Never>?
     
     public struct Options {
         public let clientId: String
@@ -337,8 +339,6 @@ public class OpenPanel {
     
     private init() {
         self.api = Api(config: Api.Config(baseUrl: "https://api.openpanel.dev"))
-        self.operationQueue = OperationQueue()
-        self.operationQueue.maxConcurrentOperationCount = 1
     }
     
     public static func initialize(options: Options) {
@@ -402,9 +402,11 @@ public class OpenPanel {
             return
         }
         
-        let operation = BlockOperation {
-            Task {
-                let updatedPayload = self.ensureProfileId(payload)
+        let updatedPayload = ensureProfileId(payload)
+        globalQueue.async(flags: .barrier) {
+            let previous = self.sendTask
+            self.sendTask = Task {
+                await previous?.value
                 let result = await self.api.fetch(path: "/track", data: updatedPayload)
                 switch result {
                 case .success:
@@ -414,7 +416,6 @@ public class OpenPanel {
                 }
             }
         }
-        operationQueue.addOperation(operation)
     }
     
     private func ensureProfileId(_ payload: TrackHandlerPayload) -> TrackHandlerPayload {

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -383,7 +383,9 @@ public class OpenPanel {
         }
         
         if options.waitForProfile == true, profileId == nil {
-            queue.append(payload)
+            globalQueue.async(flags: .barrier) {
+                self.queue.append(payload)
+            }
             return
         }
         
@@ -482,8 +484,11 @@ public class OpenPanel {
     }
     
     public func flush() {
-        let currentQueue = queue
-        queue.removeAll()
+        let currentQueue = globalQueue.sync(flags: .barrier) { () -> [TrackHandlerPayload] in
+            let items = queue
+            queue.removeAll()
+            return items
+        }
         for item in currentQueue {
             send(item)
         }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -1,88 +1,41 @@
 import Foundation
-#if os(iOS)
-import UIKit
-import WebKit
-#elseif os(tvOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #elseif os(macOS)
 import AppKit
-import WebKit
 #endif
 
 // MARK: - DeviceInfo
 
 internal class DeviceInfo {
-    static func getUserAgent() -> String {
-        #if os(iOS)
-        return getiOSUserAgent()
-        #elseif os(macOS)
-        return getMacOSUserAgent()
+    /// Hardware model identifier, e.g. "iPhone15,2", "MacBookPro18,3", "AppleTV14,1".
+    static var hardwareModel: String {
+        // Simulators report the simulator's own hardware; the simulated device is in the environment.
+        if let simulatorModel = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] {
+            return simulatorModel
+        }
+        #if os(macOS)
+        var size = 0
+        sysctlbyname("hw.model", nil, &size, nil, 0)
+        guard size > 0 else { return "Mac" }
+        var buffer = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.model", &buffer, &size, nil, 0)
+        return String(cString: buffer)
         #else
-        return getGenericUserAgent()
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machine = withUnsafeBytes(of: &systemInfo.machine) { buffer -> String in
+            guard let base = buffer.baseAddress else { return "" }
+            return String(cString: base.assumingMemoryBound(to: CChar.self))
+        }
+        return machine.isEmpty ? "Apple" : machine
         #endif
     }
-    
-    private static func isRunningInExtension() -> Bool {
-        return Bundle.main.bundlePath.hasSuffix(".appex")
-    }
 
-    #if os(iOS)
-    private static func getiOSUserAgent() -> String {
-        if !isRunningInExtension() {
-            let webView = WKWebView(frame: .zero)
-            var userAgent = ""
-            
-            let semaphore = DispatchSemaphore(value: 0)
-            
-            DispatchQueue.main.async {
-                webView.evaluateJavaScript("navigator.userAgent") { (result, error) in
-                    if let agent = result as? String {
-                        userAgent = agent
-                    }
-                    semaphore.signal()
-                }
-            }
-            
-            _ = semaphore.wait(timeout: .now() + 1.0)
-
-            if userAgent.isEmpty {
-                return getBasicUserAgent()
-            }
-
-            return userAgent + " OpenPanel/\(OpenPanel.sdkVersion)"
-        } else {
-            return getBasicUserAgent()
-        }
-    }
-
-    private static func getBasicUserAgent() -> String {
-        let device = UIDevice.current
-        let systemVersion = device.systemVersion
-        let model = device.model
-        let systemName = device.systemName
-
-        // Construct a user agent string manually with more detailed information
-        var userAgent = "Mozilla/5.0 (\(model); \(systemName) \(systemVersion.replacingOccurrences(of: ".", with: "_")); like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/\(systemVersion)"
-
-        // Append your custom string if necessary
-        userAgent += " OpenPanel/\(OpenPanel.sdkVersion)"
-
-        return userAgent
-    }
-    #endif
-
-    private static func getMacOSUserAgent() -> String {
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        let version = "\(osVersion.majorVersion)_\(osVersion.minorVersion)_\(osVersion.patchVersion)"
-
-        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X \(version)) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
-        
-        return userAgent + " OpenPanel/\(OpenPanel.sdkVersion)"
-    }
-    
-    private static func getGenericUserAgent() -> String {
-        let osName = ProcessInfo.processInfo.operatingSystemVersionString
-        return "OpenPanel/\(OpenPanel.sdkVersion) (\(osName))"
+    static func getUserAgent() -> String {
+        // The Model=/Manufacturer= form is recognized by the OpenPanel backend as
+        // app traffic, so it is not classified as a server/bot request.
+        return "OpenPanel/\(OpenPanel.sdkVersion) (Model=\(hardwareModel); Manufacturer=Apple)"
     }
 }
 

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -332,7 +332,7 @@ public class OpenPanel {
     private var options: Options?
     
     public static var sdkVersion: String {
-        return "0.0.1"
+        return "1.0.1"
     }
     
     private init() {

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -37,6 +37,51 @@ internal class DeviceInfo {
         // app traffic, so it is not classified as a server/bot request.
         return "OpenPanel/\(OpenPanel.sdkVersion) (Model=\(hardwareModel); Manufacturer=Apple)"
     }
+
+    static var osName: String {
+        // Names must match ua-parser-js v2 vocabulary so app traffic shares
+        // dashboard buckets with web traffic ("macOS", not "Mac OS").
+        #if os(iOS)
+        return "iOS"
+        #elseif os(tvOS)
+        return "tvOS"
+        #elseif os(watchOS)
+        return "watchOS"
+        #elseif os(macOS)
+        return "macOS"
+        #else
+        return "Unknown"
+        #endif
+    }
+
+    static var osVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+
+    static var deviceType: String {
+        // Must match ua-parser-js v2 device types.
+        #if os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "mobile"
+        #elseif os(tvOS)
+        return "smarttv"
+        #elseif os(watchOS)
+        return "wearable"
+        #else
+        return "desktop"
+        #endif
+    }
+
+    /// Property overrides the backend prefers over user-agent parsing.
+    static func deviceProperties() -> [String: Any] {
+        return [
+            "__os": osName,
+            "__osVersion": osVersion,
+            "__device": deviceType,
+            "__brand": "Apple",
+            "__model": hardwareModel,
+        ]
+    }
 }
 
 // MARK: - Payload Types
@@ -296,7 +341,18 @@ public class OpenPanel {
     
     public static func initialize(options: Options) {
         shared.options = options
-        
+
+        let deviceDefaults = DeviceInfo.deviceProperties()
+        shared.globalQueue.async(flags: .barrier) {
+            // Device defaults sit under any user-set globals so explicit
+            // setGlobalProperties values always win.
+            var merged = deviceDefaults
+            if let existing = shared._global {
+                merged.merge(existing) { _, user in user }
+            }
+            shared._global = merged
+        }
+
         var defaultHeaders: [String: String] = [
             "openpanel-client-id": options.clientId,
             "openpanel-sdk-name": "swift",
@@ -433,8 +489,10 @@ public class OpenPanel {
     
     public static func clear() {
         shared.profileId = nil
+        // Wipe user-set globals but keep the device defaults seeded at initialize.
+        let deviceDefaults = shared.options != nil ? DeviceInfo.deviceProperties() : nil
         shared.globalQueue.async(flags: .barrier) {
-            shared._global = nil
+            shared._global = deviceDefaults
         }
     }
     

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -43,13 +43,11 @@ internal class DeviceInfo {
             
             _ = semaphore.wait(timeout: .now() + 1.0)
 
-            userAgent += " OpenPanel/\(OpenPanel.sdkVersion)"
-            
             if userAgent.isEmpty {
-                userAgent = getBasicUserAgent()
+                return getBasicUserAgent()
             }
-            
-            return userAgent
+
+            return userAgent + " OpenPanel/\(OpenPanel.sdkVersion)"
         } else {
             return getBasicUserAgent()
         }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -72,12 +72,10 @@ internal class DeviceInfo {
     #endif
 
     private static func getMacOSUserAgent() -> String {
-        let processInfo = ProcessInfo.processInfo
-        let osVersion = processInfo.operatingSystemVersionString
-        let versionParts = osVersion.components(separatedBy: " ")
-        let version = versionParts.count > 1 ? versionParts[1] : "Unknown"
-        
-        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X \(version.replacingOccurrences(of: ".", with: "_"))) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let version = "\(osVersion.majorVersion)_\(osVersion.minorVersion)_\(osVersion.patchVersion)"
+
+        let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X \(version)) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
         
         return userAgent + " OpenPanel/\(OpenPanel.sdkVersion)"
     }

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -3,6 +3,8 @@ import Foundation
 import UIKit
 #elseif os(macOS)
 import AppKit
+#elseif os(watchOS)
+import WatchKit
 #endif
 
 // MARK: - DeviceInfo
@@ -539,6 +541,19 @@ public class OpenPanel {
             name: NSApplication.willTerminateNotification,
             object: nil
         )
+        #elseif os(watchOS)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: WKExtension.applicationDidBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidEnterBackground),
+            name: WKExtension.applicationDidEnterBackgroundNotification,
+            object: nil
+        )
         #endif
     }
 
@@ -564,6 +579,14 @@ public class OpenPanel {
     }
 
     @objc private func appWillTerminate() {
+        OpenPanel.track(name: "app_closed")
+    }
+    #elseif os(watchOS)
+    @objc private func appDidBecomeActive() {
+        OpenPanel.track(name: "app_opened")
+    }
+
+    @objc private func appDidEnterBackground() {
         OpenPanel.track(name: "app_closed")
     }
     #endif

--- a/Sources/OpenPanel/OpenPanel.swift
+++ b/Sources/OpenPanel/OpenPanel.swift
@@ -2,6 +2,8 @@ import Foundation
 #if os(iOS)
 import UIKit
 import WebKit
+#elseif os(tvOS)
+import UIKit
 #elseif os(macOS)
 import AppKit
 import WebKit


### PR DESCRIPTION
> **Stacked on Openpanel-dev/swift-sdk#7** (`bugfix/macos-fixes`). Only the last 4 commits are new here; if that PR merges first this diff collapses to just them.

Replaces all user-agent fabrication with the structured device-info format the backend already understands. SDK-only — no backend changes needed. Every claim below was verified by running the actual backend parser (`packages/common/server/parser-user-agent.ts`) and bot detector against the new UAs.

## What changes

**1. One deterministic UA on every platform** (`ed1045e`)

```
OpenPanel/1.0.1 (Model=iPhone15,2; Manufacturer=Apple)
```

The `Model=…; Manufacturer=…` form is the backend's sanctioned app-traffic format (`APP_MODEL_REGEX`): it sets device model/vendor and defeats the `isServer` classification. Verified parse results for iPhone15,2, iPad13,1, MacBookPro18,3, AppleTV14,1, and Watch6,9: correct OS/device/brand/model, `isServer: false`, and none match the bot list.

This deletes the WKWebView `navigator.userAgent` evaluation (which blocked the main thread on a semaphore for a guaranteed 1 s when initialized on the main thread — the async block couldn't run until the wait timed out), both hand-built fake Safari UA strings, and the WebKit import. Hardware model comes from `sysctl hw.model` on macOS, `utsname.machine` elsewhere, `SIMULATOR_MODEL_IDENTIFIER` under simulators.

**2. Structured device properties on every event** (`8e44f3c`)

`initialize()` seeds `__os`, `__osVersion`, `__device`, `__brand`, `__model` into global properties — the overrides the backend prefers to UA parsing. Values follow the ua-parser-js v2 vocabulary (`"macOS"` not `"Mac OS"`; `mobile`/`tablet`/`desktop`/`smarttv`/`wearable`) so app traffic shares dashboard buckets with web traffic. Device defaults sit under user globals (`setGlobalProperties` always wins), and `clear()` re-seeds them rather than wiping them with user state.

This also fixes tvOS, which previously fell to a generic UA that the backend classified as **server** traffic — no sessions, no OS breakdown.

**3. watchOS support** (`627498a`)

The README has always advertised watchOS but the package never declared it. Adds `.watchOS(.v7)` (needed for the `WKExtension` lifecycle notifications), plus `app_opened`/`app_closed` observers.

**4. Real send serialization** (`6fdbea9`)

The `OperationQueue` with `maxConcurrentOperationCount = 1` never serialized requests — each `BlockOperation` spawned an unawaited `Task` and finished immediately, so events could reach the server out of order (a `track` overtaking its preceding `identify`). Sends are now a task chain: each awaits the previous one, with the chain tail guarded by the existing barrier queue. Profile id is resolved at track time rather than network time.

## Behavior changes to release-note

- **Anonymous deviceIds shift once.** `deviceId = sha256(ua:ip:origin:salt)`, and the UA changes — existing anonymous visitors get a new deviceId after upgrading. Identified profiles are unaffected.
- **Browser column is honestly empty for app traffic.** It previously showed a fake "Safari"; native apps aren't browsers, and OS/device/model reporting is now accurate instead.

## Verification

`swift build` (macOS) and `xcodebuild` for iOS, tvOS, and watchOS simulators: BUILD SUCCEEDED, zero warnings on all four platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
